### PR TITLE
Fixbug: get the modified wrong way

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,8 +63,9 @@ function deliver(output, release, content, file) {
 
 module.exports = function(options, modified, total, next) {
   var to = normalizePath(options.to || options.dest || 'preview', fis.project.getProjectPath());
+  var list = options.modified ? modified : total;
 
-  modified.forEach(function(file) {
+  list.forEach(function(file) {
     deliver(to, file.getHashRelease(), file.getContent(), file);
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fis3-deploy-local-deliver",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "fis3 deploy http-push plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
我觉得这个要规范起来，所有 `deploy` 插件都应该用这种方法获取文件列表

```
var list = options.modified ? modified : total;
```
